### PR TITLE
Rename framework xcscheme

### DIFF
--- a/TOSegmentedControlExample.xcodeproj/project.pbxproj
+++ b/TOSegmentedControlExample.xcodeproj/project.pbxproj
@@ -171,9 +171,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		228CEE3023289D4E000B055C /* TOSegmentedControlFramework */ = {
+		228CEE3023289D4E000B055C /* TOSegmentedControl */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 228CEE3D23289D4E000B055C /* Build configuration list for PBXNativeTarget "TOSegmentedControlFramework" */;
+			buildConfigurationList = 228CEE3D23289D4E000B055C /* Build configuration list for PBXNativeTarget "TOSegmentedControl" */;
 			buildPhases = (
 				228CEE2C23289D4E000B055C /* Headers */,
 				228CEE2D23289D4E000B055C /* Sources */,
@@ -184,7 +184,7 @@
 			);
 			dependencies = (
 			);
-			name = TOSegmentedControlFramework;
+			name = TOSegmentedControl;
 			productName = TOSegmentedControlFramework;
 			productReference = 228CEE3123289D4E000B055C /* TOSegmentedControl.framework */;
 			productType = "com.apple.product-type.framework";
@@ -259,7 +259,7 @@
 			projectRoot = "";
 			targets = (
 				22DF8D8422FF119C0051F319 /* TOSegmentedControlExample */,
-				228CEE3023289D4E000B055C /* TOSegmentedControlFramework */,
+				228CEE3023289D4E000B055C /* TOSegmentedControl */,
 				228CEE422328A009000B055C /* TOSegmentedControlTests */,
 			);
 		};
@@ -589,7 +589,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		228CEE3D23289D4E000B055C /* Build configuration list for PBXNativeTarget "TOSegmentedControlFramework" */ = {
+		228CEE3D23289D4E000B055C /* Build configuration list for PBXNativeTarget "TOSegmentedControl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				228CEE3B23289D4E000B055C /* Debug */,

--- a/TOSegmentedControlExample.xcodeproj/xcshareddata/xcschemes/TOSegmentedControl.xcscheme
+++ b/TOSegmentedControlExample.xcodeproj/xcshareddata/xcschemes/TOSegmentedControl.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1100"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "228CEE3023289D4E000B055C"
+               BuildableName = "TOSegmentedControl.framework"
+               BlueprintName = "TOSegmentedControl"
+               ReferencedContainer = "container:TOSegmentedControlExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "228CEE3023289D4E000B055C"
+            BuildableName = "TOSegmentedControl.framework"
+            BlueprintName = "TOSegmentedControl"
+            ReferencedContainer = "container:TOSegmentedControlExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
These changes are made to fix issue - "Dependency "TOSegmentedControl" has no shared framework schemes for any of the platforms" when trying to install via Carthage.