### PR TITLE
Enable change of selected segment item color

### DIFF
--- a/TOSegmentedControl/TOSegmentedControl.h
+++ b/TOSegmentedControl/TOSegmentedControl.h
@@ -67,6 +67,9 @@ IB_DESIGNABLE @interface TOSegmentedControl : UIControl
 /** The color of the text labels / images (Default is black) */
 @property (nonatomic, strong, null_resettable) IBInspectable UIColor *itemColor;
 
+/** The color of the selected labels / images (Default is black) */
+@property (nonatomic, strong, null_resettable) IBInspectable UIColor *selectedItemColor;
+
 /** The font of the text items (Default is system default at 10 points) */
 @property (nonatomic, strong, null_resettable) IBInspectable UIFont *textFont;
 

--- a/TOSegmentedControl/TOSegmentedControl.m
+++ b/TOSegmentedControl/TOSegmentedControl.m
@@ -155,6 +155,7 @@ static CGFloat const kTOSegmentedControlDirectionArrowAlpha = 0.4f;
     self.thumbColor = nil;
     self.separatorColor = nil;
     self.itemColor = nil;
+    self.selectedItemColor = nil;
     self.textFont = nil;
     self.selectedTextFont = nil;
 
@@ -696,6 +697,9 @@ static CGFloat const kTOSegmentedControlDirectionArrowAlpha = 0.4f;
     UIFont *font = selected ? self.selectedTextFont : self.textFont;
     label.font = font;
 
+    // Set the text color
+    label.textColor = selected ? self.selectedItemColor : self.itemColor;
+    
     // Re-apply the arrow image view to the translated frame
     segment.arrowView.frame = [self frameForImageArrowViewWithItemFrame:label.frame];
 
@@ -1198,6 +1202,29 @@ static CGFloat const kTOSegmentedControlDirectionArrowAlpha = 0.4f;
         #ifdef __IPHONE_13_0
         if (@available(iOS 13.0, *)) {
             _itemColor = [UIColor labelColor];
+        }
+        #endif
+    }
+
+    // Set each item to the color
+    for (TOSegmentedControlSegment *item in self.segments) {
+        [item refreshItemView];
+    }
+}
+
+//-------------------------------------------------
+// Selected Item Color
+
+- (void)setSelectedItemColor:(UIColor *)selectedItemColor
+{
+    _selectedItemColor = selectedItemColor;
+    if (_selectedItemColor == nil) {
+        _selectedItemColor = [UIColor blackColor];
+
+        // Assign the dynamic label color on iOS 13 and up
+        #ifdef __IPHONE_13_0
+        if (@available(iOS 13.0, *)) {
+            _selectedItemColor = [UIColor labelColor];
         }
         #endif
     }


### PR DESCRIPTION
![Screen Shot 2019-10-12 at 7 22 32 PM](https://user-images.githubusercontent.com/25865668/66705848-557b5200-ed2c-11e9-93c6-e2449b43c4ae.png)

Change Selected Text Color by
`[self.segmentedControl setSelectedItemColor:[UIColor lightGrayColor]];`
OR
`self.segmentedControl.selectedItemColor = [UIColor lightGrayColor];`