### PR TITLE
Fix broken `init(items:)` initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 x.y.z Release Notes (yyyy-MM-dd)
 =============================================================
 
+### Fixed
+
+* A bug where creating instances with `init(items:)` would yield no visible items.
+
 1.0.1 Release Notes (2019-09-24)
 =============================================================
 

--- a/TOSegmentedControl/TOSegmentedControl.m
+++ b/TOSegmentedControl/TOSegmentedControl.m
@@ -90,8 +90,8 @@ static CGFloat const kTOSegmentedControlDirectionArrowAlpha = 0.4f;
 - (instancetype)initWithItems:(NSArray *)items
 {
     if (self = [super initWithFrame:(CGRect){0.0f, 0.0f, 300.0f, 32.0f}]) {
-        _items = [self sanitizedItemArrayWithItems:items];
         [self commonInit];
+        self.items = [self sanitizedItemArrayWithItems:items];
     }
 
     return self;


### PR DESCRIPTION
I discovered that I never properly tested this init method on account of using IB. The item segments weren't being configured properly and the view was showing as empty. All fixed now!