### PR TITLE
Add iPadOS mouse pointer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 x.y.z Release Notes (yyyy-MM-dd)
 =============================================================
 
+1.2.0 Release Notes (2022-01-23)
+=============================================================
+
+### Enhancements
+
+* Added iPadOS mouse pointer support.
+
+### Fixed
+
+* Tapping a segment may not have properly played the selection animation.
+
 1.1.0 Release Notes (2020-05-20)
 =============================================================
 

--- a/TOSegmentedControl.podspec
+++ b/TOSegmentedControl.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'TOSegmentedControl'
-  s.version  = '1.1.0'
+  s.version  = '1.2.0'
   s.license  =  { :type => 'MIT', :file => 'LICENSE' }
   s.summary  = 'A segmented control in the style of iOS 13 compatible with previous versions of iOS.'
   s.homepage = 'https://github.com/TimOliver/TOSegmentedControl'

--- a/TOSegmentedControl/Private/TOSegmentedControlSegment.h
+++ b/TOSegmentedControl/Private/TOSegmentedControlSegment.h
@@ -1,7 +1,7 @@
 //
 //  TOSegmentedControlItem.h
 //
-//  Copyright 2019 Timothy Oliver. All rights reserved.
+//  Copyright 2019-2022 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/TOSegmentedControl/Private/TOSegmentedControlSegment.h
+++ b/TOSegmentedControl/Private/TOSegmentedControlSegment.h
@@ -55,6 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** Whether the item is selected or not. */
 @property (nonatomic, assign) BOOL isSelected;
 
+/** A container view that wraps the item and arrow views */
+@property (nonatomic, strong) UIView *containerView;
+
 /** The view (either image or label) for this item */
 @property (nonatomic, readonly) UIView *itemView;
 

--- a/TOSegmentedControl/Private/TOSegmentedControlSegment.m
+++ b/TOSegmentedControl/Private/TOSegmentedControlSegment.m
@@ -161,7 +161,10 @@
 #pragma mark - Set-up -
 
 - (void)commonInit
-{    
+{
+    // Create the container view
+    _containerView = [[UIView alloc] init];
+
     // Create the initial image / label view
     [self refreshItemView];
     
@@ -185,7 +188,7 @@
         UIImage *arrow = self.segmentedControl.arrowImage;
         self.arrowView = [[UIView alloc] initWithFrame:(CGRect){CGPointZero, arrow.size}];
         self.arrowView.alpha = 0.0f;
-        [self.segmentedControl.trackView addSubview:self.arrowView];
+        [self.containerView addSubview:self.arrowView];
 
         self.arrowImageView = [[UIImageView alloc] initWithImage:arrow];
         self.arrowImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -250,7 +253,7 @@
         imageView = nil;
         
         self.itemView = [self makeLabelForTitle:self.title];
-        [self.segmentedControl.trackView addSubview:self.itemView];
+        [self.containerView addSubview:self.itemView];
         
         label = (UILabel *)self.itemView;
     }
@@ -261,13 +264,14 @@
         label = nil;
         
         self.itemView = [self makeImageViewForImage:self.image];
-        [self.segmentedControl.trackView addSubview:self.itemView];
+        [self.containerView addSubview:self.itemView];
         
         imageView = (UIImageView *)self.itemView;
     }
     
     // Update the label view
     label.textColor = self.segmentedControl.itemColor;
+
     // Set the frame off the selected text as it is larger
     label.font = self.segmentedControl.selectedTextFont;
     [label sizeToFit];

--- a/TOSegmentedControl/Private/TOSegmentedControlSegment.m
+++ b/TOSegmentedControl/Private/TOSegmentedControlSegment.m
@@ -1,7 +1,7 @@
 //
 //  TOSegmentedControlItem.m
 //
-//  Copyright 2019 Timothy Oliver. All rights reserved.
+//  Copyright 2019-2022 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/TOSegmentedControl/TOSegmentedControl.h
+++ b/TOSegmentedControl/TOSegmentedControl.h
@@ -1,7 +1,7 @@
 //
 //  TOSegmentedControl.h
 //
-//  Copyright 2019 Timothy Oliver. All rights reserved.
+//  Copyright 2019-2022 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/TOSegmentedControl/TOSegmentedControl.m
+++ b/TOSegmentedControl/TOSegmentedControl.m
@@ -82,7 +82,10 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 @property (nonatomic, readonly) BOOL hasNoSegments;
 
 /** Pointer interaction for mice interactions */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 @property (nonatomic, strong) UIPointerInteraction *pointerInteraction;
+#pragma clang diagnostic pop
 
 @end
 
@@ -403,6 +406,8 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 - (void)removeSegmentAtIndex:(NSInteger)index
 {
     if (index < 0 || index >= self.items.count) { return; }
+
+    
 
     // Remove from the item list
     NSMutableArray *items = self.items.mutableCopy;

--- a/TOSegmentedControl/TOSegmentedControl.m
+++ b/TOSegmentedControl/TOSegmentedControl.m
@@ -1,7 +1,7 @@
 //
 //  TOSegmentedControl.m
 //
-//  Copyright 2019 Timothy Oliver. All rights reserved.
+//  Copyright 2019-2022 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/TOSegmentedControl/TOSegmentedControl.m
+++ b/TOSegmentedControl/TOSegmentedControl.m
@@ -81,6 +81,9 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 /** Convenience property for testing if there are no segments */
 @property (nonatomic, readonly) BOOL hasNoSegments;
 
+/** Pointer interaction for mice interactions */
+@property (nonatomic, strong) UIPointerInteraction *pointerInteraction;
+
 @end
 
 @implementation TOSegmentedControl
@@ -167,10 +170,13 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
     self.thumbShadowOffset = 2.0f;
     self.thumbShadowOpacity = 0.13f;
 
+    // Set focused index to -1 to indicate nothing is focused
+    self.focusedIndex = -1;
+
     // Configure indirect pointing support
     if (@available(iOS 13.4, *)) {
-        UIPointerInteraction *pointerInteraction = [[UIPointerInteraction alloc] initWithDelegate:self];
-        [self addInteraction:pointerInteraction];
+        self.pointerInteraction = [[UIPointerInteraction alloc] initWithDelegate:self];
+        [self addInteraction:self.pointerInteraction];
     }
 
     // Configure view interaction
@@ -532,11 +538,12 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
     for (TOSegmentedControlSegment *item in self.segments) {
         UIView *itemView = item.itemView;
         [itemView sizeToFit];
-        [self.trackView addSubview:itemView];
+        [self.trackView addSubview:item.containerView];
 
         // Get the container frame that the item will be aligned with
         CGRect thumbFrame = [self frameForSegmentAtIndex:i];
-        
+        item.containerView.frame = thumbFrame;
+
         // Work out the appropriate size of the item
         CGRect itemFrame = itemView.frame;
         
@@ -551,8 +558,8 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
         }
         
         // Center the item in the container
-        itemFrame.origin.x = CGRectGetMidX(thumbFrame) - (itemFrame.size.width * 0.5f);
-        itemFrame.origin.y = CGRectGetMidY(thumbFrame) - (itemFrame.size.height * 0.5f);
+        itemFrame.origin.x = (CGRectGetWidth(thumbFrame) - itemFrame.size.width) * 0.5f;
+        itemFrame.origin.y = (CGRectGetHeight(thumbFrame) - itemFrame.size.height) * 0.5f;
         
         // Set the item frame
         itemView.frame = CGRectIntegral(itemFrame);
@@ -754,6 +761,11 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 
 - (void)refreshSeparatorViewsForSelectedIndex:(NSInteger)index
 {
+    [self refreshSeparatorViewsForSelectedIndexes:[NSSet setWithObject:@(index)]];
+}
+
+- (void)refreshSeparatorViewsForSelectedIndexes:(NSSet<NSNumber *> *)indexes
+{
     // Hide the separators on either side of the selected segment
     NSInteger i = 0;
     for (UIView *separatorView in self.separatorViews) {
@@ -763,7 +775,9 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
             continue;
         }
 
-        separatorView.alpha = (i == index || i == (index - 1)) ? 0.0f : 1.0f;
+        // Hide the index (right side) and the previous index (left side) if it's in the set
+        BOOL containsIndex = ([indexes containsObject:@(i)] || [indexes containsObject:@(i+1)]);
+        separatorView.alpha = containsIndex ? 0.0f : 1.0f;
         i++;
     }
 }
@@ -792,6 +806,11 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 
     // Track the currently selected item as the focused one
     self.focusedIndex = tappedIndex;
+
+    // On iOS 13.4, update the point interaction
+    if (@available(iOS 13.4, *)) {
+        [self.pointerInteraction invalidate];
+    }
 
     // Work out which animation effects to apply
     if (!self.isDraggingThumbView) {
@@ -823,7 +842,12 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 
     CGPoint tapPoint = [event.allTouches.anyObject locationInView:self];
     NSInteger tappedIndex = [self segmentIndexForPoint:tapPoint];
-    
+
+    // On iOS 13.4, update the point interaction
+    if (@available(iOS 13.4, *)) {
+        [self.pointerInteraction invalidate];
+    }
+
     if (tappedIndex == self.focusedIndex) {
       return;
     }
@@ -969,6 +993,11 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
         // Reset the focused index flag
         self.focusedIndex = -1;
 
+        // On iOS 13.4, update the point interaction
+        if (@available(iOS 13.4, *)) {
+            [self.pointerInteraction invalidate];
+        }
+
         return;
     }
 
@@ -982,6 +1011,11 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
         // trigger the reverse alert delegate
         [segment toggleDirection];
         [self sendIndexChangedEventActions];
+    }
+
+    // On iOS 13.4, update the point interaction
+    if (@available(iOS 13.4, *)) {
+        [self.pointerInteraction invalidate];
     }
 
     // Work out which animation effects to apply
@@ -1025,26 +1059,70 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 {
     CGRect frame = defaultRegion.rect;
 
+    // Determine which segment the pointer is in
     CGFloat segmentWidth = frame.size.width / self.segments.count;
     CGPoint location = request.location;
     NSInteger segment = floorf(location.x / segmentWidth);
 
+    // Define the selectable region for this segment
     frame.origin.x = segmentWidth * segment;
     frame.size.width = segmentWidth;
 
+    // Return the region and an identifier for the segment
     return [UIPointerRegion regionWithRect:frame identifier:@(segment)];
 }
 
 - (UIPointerStyle *)pointerInteraction:(UIPointerInteraction *)interaction
                         styleForRegion:(UIPointerRegion *)region API_AVAILABLE(ios(13.4))
 {
+    // Fetch which segment was selected
     NSInteger segment = [(NSNumber *)region.identifier integerValue];
 
+    // Fetch the frame size of the segment
     CGRect frame = [self frameForSegmentAtIndex:segment];
-    frame.origin = CGPointZero;
 
-    UIPointerShape *shape = [UIPointerShape shapeWithRoundedRect:frame cornerRadius:self.thumbView.layer.cornerRadius];
-    return [UIPointerStyle styleWithShape:shape constrainedAxes:UIAxisBoth];
+    // Create a preview link to the container view containing the item and arrow
+    UITargetedPreview *preview = [[UITargetedPreview alloc] initWithView:[self.segments[segment] containerView]];
+
+    // Define the selection shape as the size of the segment with the thumb's corner radius
+    UIPointerShape *shape = [UIPointerShape shapeWithRoundedRect:frame
+                                                    cornerRadius:self.thumbView.layer.cornerRadius];
+
+    // For selected segments
+    UIPointerEffect *effect = nil;
+    if (segment == self.selectedSegmentIndex) {
+        effect = [UIPointerLiftEffect effectWithPreview:preview];
+    } else { // Un-selected segments
+        effect = [UIPointerHighlightEffect effectWithPreview:preview];
+    }
+
+    // Return the final generated shape
+    return [UIPointerStyle styleWithEffect:effect shape:shape];
+}
+
+- (void)pointerInteraction:(UIPointerInteraction *)interaction
+           willEnterRegion:(UIPointerRegion *)region
+                  animator:(id<UIPointerInteractionAnimating>)animator API_AVAILABLE(ios(13.4))
+{
+    NSInteger segment = [(NSNumber *)region.identifier integerValue];
+    NSSet *selectedSegments = [NSSet setWithArray:@[@(segment), @(self.selectedSegmentIndex)]];
+
+    // Animate the separator views fading in and out to match
+    [animator addAnimations:^{
+        [self refreshSeparatorViewsForSelectedIndexes:selectedSegments];
+    }];
+}
+
+- (void)pointerInteraction:(UIPointerInteraction *)interaction
+            willExitRegion:(UIPointerRegion *)region
+                  animator:(id<UIPointerInteractionAnimating>)animator API_AVAILABLE(ios(13.4))
+{
+    // Restore the thumb view
+    self.trackView.clipsToBounds = YES;
+
+    [animator addAnimations:^{
+        [self refreshSeparatorViewsForSelectedIndex:self.selectedSegmentIndex];
+    }];
 }
 
 #pragma mark - Accessors -

--- a/TOSegmentedControl/TOSegmentedControl.m
+++ b/TOSegmentedControl/TOSegmentedControl.m
@@ -407,14 +407,13 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 {
     if (index < 0 || index >= self.items.count) { return; }
 
-    
-
     // Remove from the item list
     NSMutableArray *items = self.items.mutableCopy;
     [items removeObjectAtIndex:index];
     _items = items;
 
     // Remove item object
+    [self.segments[index].containerView removeFromSuperview];
     [self.segments removeObjectAtIndex:index];
 
     // Update number of separators
@@ -424,6 +423,9 @@ static CGFloat const kTOSegmentedControlDirectionArrowMargin = 2.0f;
 - (void)removeAllSegments
 {
     // Remove all item objects
+    for (TOSegmentedControlSegment * segment in self.segments) {
+        [segment.containerView removeFromSuperview];
+    }
     self.segments = [NSMutableArray array];
 
     // Remove all separators

--- a/TOSegmentedControlExample.xcodeproj/project.pbxproj
+++ b/TOSegmentedControlExample.xcodeproj/project.pbxproj
@@ -555,7 +555,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				INFOPLIST_FILE = TOSegmentedControlExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -573,7 +573,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 6LF3GMKZAB;
 				INFOPLIST_FILE = TOSegmentedControlExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/TOSegmentedControlExample.xcodeproj/project.pbxproj
+++ b/TOSegmentedControlExample.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		22C93B05232AA79900A281CA /* TOSegmentedControl.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; path = TOSegmentedControl.h; sourceTree = "<group>"; };
 		22C93B07232ADBEA00A281CA /* TOSegmentedControlSegment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TOSegmentedControlSegment.h; sourceTree = "<group>"; };
 		22C93B0D232ADFDD00A281CA /* TOSegmentedControlSegment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TOSegmentedControlSegment.m; sourceTree = "<group>"; };
+		22D83E6E279D2F3700CF0D8E /* TOSegmentedControl.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = TOSegmentedControl.podspec; sourceTree = "<group>"; };
 		22DF8D8522FF119C0051F319 /* TOSegmentedControlExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TOSegmentedControlExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		22DF8D8822FF119C0051F319 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		22DF8D8922FF119C0051F319 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -127,6 +128,7 @@
 				22DF8D8622FF119C0051F319 /* Products */,
 				22E1FE3A232F7F0600CE1C92 /* README.md */,
 				22E1FE3B232F7F0D00CE1C92 /* CHANGELOG.md */,
+				22D83E6E279D2F3700CF0D8E /* TOSegmentedControl.podspec */,
 			);
 			sourceTree = "<group>";
 		};


### PR DESCRIPTION
This brings the behaviour of this control when interacting with the iPadOS mouse pointer API more in line with the official API.

It's not 100% perfect. In `UISegmentedControl`, when the pointer drags over the selected segment, the white rounded rectangle expands with the text to denote it's selected. Unfortunately, due to the way the view hierarchy works, this ended up being extremely difficult to replicate perfectly.

This implementation is "fine" for 99% percent of cases, but I might try this again down the line.